### PR TITLE
Refactor update-hosts script

### DIFF
--- a/templates/update-hosts.sh.j2
+++ b/templates/update-hosts.sh.j2
@@ -3,7 +3,7 @@
 # cloud nodes hostname are expected to be of this kind:
 # suffix-general_category-flavor_description-random_number.domain
 
-tmp=`mktemp`
+tmp=$(mktemp)
 
 grep -v '^{{ cloud_network_prefix }}' /etc/hosts | sort -unt. -k1,1 -k2,2 -k3,3 -k4,4 > $tmp
 
@@ -19,18 +19,54 @@ condor_status -af Machine MyAddress -constraint 'ParentSlotId is undefined && My
 chmod 644 $tmp
 # Replace our hosts
 mv $tmp /etc/hosts
+
 {% if update_hosts_genderfile %}
 echo "$(cat /etc/hosts | grep {{ cloud_network_prefix }} | awk '{print $2}' | paste -s -d,) cloud" > /etc/genders
-
 for group in $(cat /etc/hosts | grep {{ cloud_network_prefix }} | awk '{print $2}' | awk -F- '{print $3}' | sort -u); do
 	echo "$(cat /etc/hosts | grep {{ cloud_network_prefix }} | awk '{print $2}' | grep $group | paste -s -d,) $group" >> /etc/genders
 done
 {% else %}
-mkdir -p {{ update_hosts_pssh_path }}
 
-echo "$(cat /etc/hosts | grep {{ cloud_network_prefix }} | awk '{print $2}')" > /etc/pssh/cloud
 
-for group in $(cat /etc/hosts | grep {{ cloud_network_prefix }} | awk '{print $2}' | awk -F- '{print $3}' | sort -u); do
-	echo "$(cat /etc/hosts | grep {{ cloud_network_prefix }} | awk '{print $2}' | grep $group)" >> "/etc/pssh/$group"
-done
+pssh_dir="{{ update_hosts_pssh_path }}"
+mkdir -p "$pssh_dir"
+awk -v prefix="{{ cloud_network_prefix }}" -v dir="$pssh_dir" '
+    # Only keep lines whose IP (field 1) starts with the cloud prefix
+    index($1, prefix) == 1 {
+        host = $2
+
+        # Optional: strip domain part for grouping, but keep full host in files
+        split(host, h, ".")
+        split(h[1], parts, "-")
+
+        # 3rd dash-separated piece is the group:
+        # suffix-general_category-flavor_description-random_number
+        group = parts[3]
+
+        # All cloud hosts go to "cloud" (one per line, unique)
+        if (!seen_cloud[host]++) {
+            print host > (dir "/cloud")
+        }
+
+        # Per-group hosts (one per line, unique per group)
+        key = group SUBSEP host
+        if (!seen_group[key]++) {
+            print host > (dir "/" group)
+        }
+    }
+' /etc/hosts
 {% endif %}
+
+# Updates Bare Metal file.
+tmp=$(mktemp -d)
+
+curl -sS https://raw.githubusercontent.com/usegalaxy-eu/vgcn-infrastructure-playbook/main/hosts | awk -v pssh_dir="$tmp" '
+/^\[/ { group = substr($1, 2, length($1)-2); next }
+/.*\.bi\.privat/ {
+    hostname = $1
+    file = pssh_dir "/" group
+    print hostname >> file
+    print hostname >> pssh_dir "/bare-metal"
+}
+'
+cp -r $tmp/* /etc/pssh/

--- a/templates/update-hosts.sh.j2
+++ b/templates/update-hosts.sh.j2
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # cloud nodes hostname are expected to be of this kind:
 # suffix-general_category-flavor_description-random_number.domain
@@ -60,7 +61,7 @@ awk -v prefix="{{ cloud_network_prefix }}" -v dir="$pssh_dir" '
 # Updates Bare Metal file.
 tmp=$(mktemp -d)
 
-curl -sS https://raw.githubusercontent.com/usegalaxy-eu/vgcn-infrastructure-playbook/main/hosts | awk -v pssh_dir="$tmp" '
+curl -fsS https://raw.githubusercontent.com/usegalaxy-eu/vgcn-infrastructure-playbook/main/hosts | awk -v pssh_dir="$tmp" '
 /^\[/ { group = substr($1, 2, length($1)-2); next }
 /.*\.bi\.privat/ {
     hostname = $1

--- a/templates/update-hosts.sh.j2
+++ b/templates/update-hosts.sh.j2
@@ -5,13 +5,15 @@
 
 tmp=`mktemp`
 
-cat /etc/hosts| grep -v '^{{ cloud_network_prefix }}' | sort | uniq > $tmp
+grep -v '^{{ cloud_network_prefix }}' /etc/hosts | sort -unt. -k1,1 -k2,2 -k3,3 -k4,4 > $tmp
 
-condor_status -autoformat Machine MyAddress | grep -v privat | grep novalocal | \
+condor_status -af Machine MyAddress -constraint 'ParentSlotId is undefined && MyAddress isnt undefined' | \
+    grep -v privat | \
+    grep novalocal | \
     cut -f1 -d: | \
-    sed 's/<//g;s/{{ hostname_suffix }}//g'| \
+    sed 's/<//g;s/.novalocal//g'| \
     awk '{print $2" "$1}'| \
-    sort -uk2 >> $tmp
+    sort -unt. -k1,1 -k2,2 -k3,3 -k4,4 >> $tmp
 
 # Fix permissions
 chmod 644 $tmp


### PR DESCRIPTION
- [x] better `/etc/hosts`  cloud grouping according to Stephan's script
- [x] Add Mira bare metal cleanup script - I decided to put in the same script file instead of having another script under `/usr/sbin`. I think if we want to decouple then we should also decouple for the cloud vms (?)
- [x] Fixes dupliacted hosts under `/etc/pssh/cXXmXX`

I have tested running the script and looks good ! 

xref: https://github.com/usegalaxy-eu/issues/issues/846